### PR TITLE
add equiv in readme and docstring

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This is the list of symbols that can be used:
 | NAND | `⊼` (`\nand<tab>`) |
 | NOR  | `⊽` (`\nor<tab>`) |
 | IMPLICATION | `-->` |
-| EQUIVALENCE | `<-->` |
+| EQUIVALENCE | `<-->`, `≡` (`\equiv<tab>`) |
 
 Examples:
 

--- a/src/macro.jl
+++ b/src/macro.jl
@@ -88,7 +88,7 @@ If `full` is `true`, the truth table will be created in expanded form.
 * NAND: `⊼` (`\\nand<tab>`)
 * NOR: `⊽` (`\\nor<tab>`)
 * IMPLICATION: `-->`
-* EQUIVALENCE: `<-->`
+* EQUIVALENCE: `<-->`, `≡` (`\\equiv<tab>`)
 
 # Examples
 


### PR DESCRIPTION
I just added the equivalence symbol in the readme and the docstring. 