### PR TITLE
Add Show Mode

### DIFF
--- a/src/TruthTables.jl
+++ b/src/TruthTables.jl
@@ -3,7 +3,6 @@ module TruthTables
 using Tables, PrettyTables
 
 export @truthtable
-export showmode!
 export -->, <-->
 export ∧, ∨, ¬
 

--- a/src/TruthTables.jl
+++ b/src/TruthTables.jl
@@ -3,6 +3,7 @@ module TruthTables
 using Tables, PrettyTables
 
 export @truthtable
+export showmode!
 export -->, <-->
 export ∧, ∨, ¬
 

--- a/src/TruthTables.jl
+++ b/src/TruthTables.jl
@@ -6,6 +6,7 @@ export @truthtable
 export -->, <-->
 export ∧, ∨, ¬
 
+include("showmode.jl")
 include("truthtable.jl")
 include("tables.jl")
 include("macro.jl")

--- a/src/showmode.jl
+++ b/src/showmode.jl
@@ -1,13 +1,13 @@
-const SHOW_MODE = Ref(:default)
+const SHOW_MODE = Ref(:bool)
 
 """
-    TruthTables.showmode!(mode::Symbol = :default)
+    TruthTables.showmode!(mode::Symbol = :bool)
 
-Changes the show mode of TruthTable type.\\
-The mode argument can be one of these symbols: `:default`, `:bit` or `:letter`.\\
-If mode is `:default`, the boolean values (`true` and `false`) will be show without formatting.\\
-If mode is `:bit`, `true` and `false` will be show as `1` and `0`.\\
-If mode is `:letter`, `true` and `false` will be show as `T` and `F`.
+Changes the way `TruthTable`s are displayed.\\
+The mode argument can be one of these symbols: `:bool` (default), `:bit` or `:letter`.\\
+`:bool` will use the boolean values (`true` and `false`) without formatting.\\
+`:bit` will use `1` and `0` for `true` and `false`, respectively.\\
+`:letter` will use T for `true` and F for `false`.
 
 # Examples
 
@@ -57,7 +57,7 @@ TruthTable
 
 
 julia> TruthTables.showmode!()
-:default
+:bool
 
 julia> tt
 TruthTable
@@ -72,13 +72,13 @@ TruthTable
 ```
 """
 function showmode!(mode::Symbol)
-    if mode ∉ (:default, :bit, :letter)
-        throw(ArgumentError("Invalid show mode, use :default, :bit or :letter."))
+    if mode ∉ (:bool, :bit, :letter)
+        throw(ArgumentError("Invalid show mode, use :bool, :bit or :letter."))
     end
     SHOW_MODE[] = mode
 end
 
-showmode!() = (SHOW_MODE[] = :default)
+showmode!() = (SHOW_MODE[] = :bool)
 
 # formatters
 _bit_formatter(v, i, j) = Int(v)
@@ -86,7 +86,7 @@ _letter_formatter(v, i, j) = v ? "T" : "F"
 
 function getformatter()
     mode = SHOW_MODE[]
-    mode == :default && return nothing
+    mode == :bool && return nothing
     mode == :bit && return _bit_formatter
     mode == :letter && return _letter_formatter
     return nothing

--- a/src/showmode.jl
+++ b/src/showmode.jl
@@ -1,0 +1,93 @@
+const SHOW_MODE = Ref(:default)
+
+"""
+    TruthTables.showmode!(mode::Symbol = :default)
+
+Changes the show mode of TruthTable type.\\
+The mode argument can be one of these symbols: `:default`, `:bit` or `:letter`.\\
+If mode is `:default`, the boolean values (`true` and `false`) will be show without formatting.\\
+If mode is `:bit`, `true` and `false` will be show as `1` and `0`.\\
+If mode is `:letter`, `true` and `false` will be show as `T` and `F`.
+
+# Examples
+
+```julia
+julia> using TruthTables
+
+julia> tt = @truthtable p && q
+TruthTable
+┌───────┬───────┬───────┐
+│   p   │   q   │ p ∧ q │
+├───────┼───────┼───────┤
+│ true  │ true  │ true  │
+│ false │ true  │ false │
+│ true  │ false │ false │
+│ false │ false │ false │
+└───────┴───────┴───────┘
+
+
+julia> TruthTables.showmode!(:bit)
+:bit
+
+julia> tt
+TruthTable
+┌───┬───┬───────┐
+│ p │ q │ p ∧ q │
+├───┼───┼───────┤
+│ 1 │ 1 │ 1     │
+│ 0 │ 1 │ 0     │
+│ 1 │ 0 │ 0     │
+│ 0 │ 0 │ 0     │
+└───┴───┴───────┘
+
+
+julia> TruthTables.showmode!(:letter)
+:letter
+
+julia> tt
+TruthTable
+┌───┬───┬───────┐
+│ p │ q │ p ∧ q │
+├───┼───┼───────┤
+│ T │ T │ T     │
+│ F │ T │ F     │
+│ T │ F │ F     │
+│ F │ F │ F     │
+└───┴───┴───────┘
+
+
+julia> TruthTables.showmode!()
+:default
+
+julia> tt
+TruthTable
+┌───────┬───────┬───────┐
+│   p   │   q   │ p ∧ q │
+├───────┼───────┼───────┤
+│ true  │ true  │ true  │
+│ false │ true  │ false │
+│ true  │ false │ false │
+│ false │ false │ false │
+└───────┴───────┴───────┘
+```
+"""
+function showmode!(mode::Symbol)
+    if mode ∉ (:default, :bit, :letter)
+        throw(ArgumentError("Invalid show mode, use :default, :bit or :letter."))
+    end
+    SHOW_MODE[] = mode
+end
+
+showmode!() = (SHOW_MODE[] = :default)
+
+# formatters
+_bit_formatter(v, i, j) = Int(v)
+_letter_formatter(v, i, j) = v ? "T" : "F"
+
+function getformatter()
+    mode = SHOW_MODE[]
+    mode == :default && return nothing
+    mode == :bit && return _bit_formatter
+    mode == :letter && return _letter_formatter
+    return nothing
+end

--- a/src/truthtable.jl
+++ b/src/truthtable.jl
@@ -20,38 +20,3 @@ function Base.show(io::IO, table::TruthTable)
         alignment=:l
     )
 end
-
-# show mode
-const SHOW_MODE = Ref(:default)
-
-"""
-    TruthTables.showmode!(mode::Symbol = :default)
-
-Description...
-
-# Examples
-
-```julia
-# code...
-```
-"""
-function showmode!(mode::Symbol)
-    if mode ∉ (:default, :bit, :letter)
-        throw(ArgumentError("Invalid show mode, use :default, :bit or :letter."))
-    end
-    SHOW_MODE[] = mode
-end
-
-showmode!() = (SHOW_MODE[] = :default)
-
-# formatters
-_bit_formatter(v, i, j) = Int(v)
-_letter_formatter(v, i, j) = v ? "T" : "F"
-
-function getformatter()
-    mode = SHOW_MODE[]
-    mode == :default && return nothing
-    mode == :bit && return _bit_formatter
-    mode == :letter && return _letter_formatter
-    return nothing
-end

--- a/src/truthtable.jl
+++ b/src/truthtable.jl
@@ -24,14 +24,25 @@ end
 # show mode
 const SHOW_MODE = Ref(:default)
 
-showmode!() = (SHOW_MODE[] = :default)
+"""
+    TruthTables.showmode!(mode::Symbol = :default)
 
+Description...
+
+# Examples
+
+```julia
+# code...
+```
+"""
 function showmode!(mode::Symbol)
     if mode ∉ (:default, :bit, :letter)
         throw(ArgumentError("Invalid show mode, use :default, :bit or :letter."))
     end
     SHOW_MODE[] = mode
 end
+
+showmode!() = (SHOW_MODE[] = :default)
 
 # formatters
 _bit_formatter(v, i, j) = Int(v)

--- a/src/truthtable.jl
+++ b/src/truthtable.jl
@@ -10,11 +10,37 @@ function TruthTable(columns::Vector{Vector{Bool}}, colnames::Vector{Symbol})
 end
 
 function Base.show(io::IO, table::TruthTable)
+    formatter = getformatter()
     println(io, "TruthTable")
     pretty_table(io, table, 
         vcrop_mode=:middle, 
         header_alignment=:c, 
         header=table.colnames, 
+        formatters=formatter,
         alignment=:l
     )
+end
+
+# show mode
+const SHOW_MODE = Ref(:bool)
+
+showmode!() = (SHOW_MODE[] = :bool)
+
+function showmode!(mode::Symbol)
+    if mode ∉ (:bool, :bit, :letter)
+        throw(ArgumentError("Invalid show mode, use :bool, :bit or :letter."))
+    end
+    SHOW_MODE[] = mode
+end
+
+# formatters
+_bit_formatter(v, i, j) = Int(v)
+_letter_formatter(v, i, j) = v ? "T" : "F"
+
+function getformatter()
+    mode = SHOW_MODE[]
+    mode == :bool && return nothing
+    mode == :bit && return _bit_formatter
+    mode == :letter && return _letter_formatter
+    return nothing
 end

--- a/src/truthtable.jl
+++ b/src/truthtable.jl
@@ -22,13 +22,13 @@ function Base.show(io::IO, table::TruthTable)
 end
 
 # show mode
-const SHOW_MODE = Ref(:bool)
+const SHOW_MODE = Ref(:default)
 
-showmode!() = (SHOW_MODE[] = :bool)
+showmode!() = (SHOW_MODE[] = :default)
 
 function showmode!(mode::Symbol)
-    if mode ∉ (:bool, :bit, :letter)
-        throw(ArgumentError("Invalid show mode, use :bool, :bit or :letter."))
+    if mode ∉ (:default, :bit, :letter)
+        throw(ArgumentError("Invalid show mode, use :default, :bit or :letter."))
     end
     SHOW_MODE[] = mode
 end
@@ -39,7 +39,7 @@ _letter_formatter(v, i, j) = v ? "T" : "F"
 
 function getformatter()
     mode = SHOW_MODE[]
-    mode == :bool && return nothing
+    mode == :default && return nothing
     mode == :bit && return _bit_formatter
     mode == :letter && return _letter_formatter
     return nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,6 @@
 using Test, Tables
 using TruthTables
 using TruthTables: TruthTable
-using TruthTables: -->, <-->, ∧, ∨, ¬
 
 @testset "TruthTables.jl" begin
     @testset "TruthTable" begin
@@ -72,6 +71,7 @@ using TruthTables: -->, <-->, ∧, ∨, ¬
     end
 
     @testset "TruthTable show" begin
+        # show mode: :bool (default)
         tt = @truthtable p && (q || r)
         str = """
         TruthTable
@@ -88,9 +88,48 @@ using TruthTables: -->, <-->, ∧, ∨, ¬
         │ false │ false │ false │ false       │
         └───────┴───────┴───────┴─────────────┘
         """
-        
         @test sprint(show, tt) == str
 
+        # show mode: :bit
+        TruthTables.showmode!(:bit)
+        str = """
+        TruthTable
+        ┌───┬───┬───┬─────────────┐
+        │ p │ q │ r │ p ∧ (q ∨ r) │
+        ├───┼───┼───┼─────────────┤
+        │ 1 │ 1 │ 1 │ 1           │
+        │ 0 │ 1 │ 1 │ 0           │
+        │ 1 │ 0 │ 1 │ 1           │
+        │ 0 │ 0 │ 1 │ 0           │
+        │ 1 │ 1 │ 0 │ 1           │
+        │ 0 │ 1 │ 0 │ 0           │
+        │ 1 │ 0 │ 0 │ 0           │
+        │ 0 │ 0 │ 0 │ 0           │
+        └───┴───┴───┴─────────────┘
+        """
+        @test sprint(show, tt) == str
+
+        # show mode: :letter
+        TruthTables.showmode!(:letter)
+        str = """
+        TruthTable
+        ┌───┬───┬───┬─────────────┐
+        │ p │ q │ r │ p ∧ (q ∨ r) │
+        ├───┼───┼───┼─────────────┤
+        │ T │ T │ T │ T           │
+        │ F │ T │ T │ F           │
+        │ T │ F │ T │ T           │
+        │ F │ F │ T │ F           │
+        │ T │ T │ F │ T           │
+        │ F │ T │ F │ F           │
+        │ T │ F │ F │ F           │
+        │ F │ F │ F │ F           │
+        └───┴───┴───┴─────────────┘
+        """
+        @test sprint(show, tt) == str
+
+        # show mode: :bool (default)
+        TruthTables.showmode!()
         tt = @truthtable p && (q || r) full=true
         str = """
         TruthTable
@@ -107,8 +146,48 @@ using TruthTables: -->, <-->, ∧, ∨, ¬
         │ false │ false │ false │ false │ false       │
         └───────┴───────┴───────┴───────┴─────────────┘
         """
-        
         @test sprint(show, tt) == str
+
+        # show mode: :bit
+        TruthTables.showmode!(:bit)
+        str = """
+        TruthTable
+        ┌───┬───┬───┬───────┬─────────────┐
+        │ p │ q │ r │ q ∨ r │ p ∧ (q ∨ r) │
+        ├───┼───┼───┼───────┼─────────────┤
+        │ 1 │ 1 │ 1 │ 1     │ 1           │
+        │ 0 │ 1 │ 1 │ 1     │ 0           │
+        │ 1 │ 0 │ 1 │ 1     │ 1           │
+        │ 0 │ 0 │ 1 │ 1     │ 0           │
+        │ 1 │ 1 │ 0 │ 1     │ 1           │
+        │ 0 │ 1 │ 0 │ 1     │ 0           │
+        │ 1 │ 0 │ 0 │ 0     │ 0           │
+        │ 0 │ 0 │ 0 │ 0     │ 0           │
+        └───┴───┴───┴───────┴─────────────┘
+        """
+        @test sprint(show, tt) == str
+
+        # show mode: :letter
+        TruthTables.showmode!(:letter)
+        str = """
+        TruthTable
+        ┌───┬───┬───┬───────┬─────────────┐
+        │ p │ q │ r │ q ∨ r │ p ∧ (q ∨ r) │
+        ├───┼───┼───┼───────┼─────────────┤
+        │ T │ T │ T │ T     │ T           │
+        │ F │ T │ T │ T     │ F           │
+        │ T │ F │ T │ T     │ T           │
+        │ F │ F │ T │ T     │ F           │
+        │ T │ T │ F │ T     │ T           │
+        │ F │ T │ F │ T     │ F           │
+        │ T │ F │ F │ F     │ F           │
+        │ F │ F │ F │ F     │ F           │
+        └───┴───┴───┴───────┴─────────────┘
+        """
+        @test sprint(show, tt) == str
+
+        @test :bool == TruthTables.showmode!()
+        @test_throws ArgumentError TruthTables.showmode!(:test)
     end
 
     @testset "Logical operators" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -71,7 +71,10 @@ using TruthTables: TruthTable
     end
 
     @testset "TruthTable show" begin
-        # show mode: :bool (default)
+        # default show mode
+        @test TruthTables.showmode!() == :bool
+        
+        # show mode: :bool
         tt = @truthtable p && (q || r)
         str = """
         TruthTable
@@ -186,7 +189,21 @@ using TruthTables: TruthTable
         """
         @test sprint(show, tt) == str
 
-        @test :bool == TruthTables.showmode!()
+        # getformatter
+        TruthTables.showmode!(:bit)
+        @test TruthTables.getformatter() === TruthTables._bit_formatter
+        TruthTables.showmode!(:letter)
+        @test TruthTables.getformatter() === TruthTables._letter_formatter
+        TruthTables.showmode!(:bool)
+        @test TruthTables.getformatter() === nothing
+
+        # formatters
+        @test TruthTables._bit_formatter(true, 1, 1) == 1
+        @test TruthTables._bit_formatter(false, 1, 1) == 0
+        @test TruthTables._letter_formatter(true, 1, 1) == "T"
+        @test TruthTables._letter_formatter(false, 1, 1) == "F"
+
+        # throws
         @test_throws ArgumentError TruthTables.showmode!(:test)
     end
 


### PR DESCRIPTION
This PR adds Show Mode for the TruthTable type.
Once a Show Mode is set, it will be used to display all objects created after that.

## Usage
```julia
julia> using TruthTables

julia> tt = @truthtable p && q
TruthTable
┌───────┬───────┬───────┐
│   p   │   q   │ p ∧ q │
├───────┼───────┼───────┤
│ true  │ true  │ true  │
│ false │ true  │ false │
│ true  │ false │ false │
│ false │ false │ false │
└───────┴───────┴───────┘


julia> TruthTables.showmode!(:bit)
:bit

julia> tt
TruthTable
┌───┬───┬───────┐
│ p │ q │ p ∧ q │
├───┼───┼───────┤
│ 1 │ 1 │ 1     │
│ 0 │ 1 │ 0     │
│ 1 │ 0 │ 0     │
│ 0 │ 0 │ 0     │
└───┴───┴───────┘


julia> TruthTables.showmode!(:letter)
:letter

julia> tt
TruthTable
┌───┬───┬───────┐
│ p │ q │ p ∧ q │
├───┼───┼───────┤
│ T │ T │ T     │
│ F │ T │ F     │
│ T │ F │ F     │
│ F │ F │ F     │
└───┴───┴───────┘
```