### PR TITLE
Resolve issue #18

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,8 @@ This is the list of symbols that can be used:
 | XOR  | `⊻` (`\xor<tab>`) |
 | NAND | `⊼` (`\nand<tab>`) |
 | NOR  | `⊽` (`\nor<tab>`) |
-| IMPLICATION | `-->`, `→` (`\to<tab>` or `\rightarrow<tab>`) |
-| EQUIVALENCE | `<-->`, `≡` (`\equiv<tab>`) |
+| IMPLICATION | `-->`, `→` (`\to<tab>` or `\rightarrow<tab>`), `⇒` ( `\Rightarrow<tab>`) |
+| EQUIVALENCE | `<-->`, `≡` (`\equiv<tab>`), `↔` (`\leftrightarrow<tab>`), `⇔` (`\Leftrightarrow<tab>`) |
 
 Examples:
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ This is the list of symbols that can be used:
 | NAND | `⊼` (`\nand<tab>`) |
 | NOR  | `⊽` (`\nor<tab>`) |
 | IMPLICATION | `-->`, `→` (`\to<tab>` or `\rightarrow<tab>`), `⇒` ( `\Rightarrow<tab>`) |
-| EQUIVALENCE | `<-->`, `≡` (`\equiv<tab>`), `↔` (`\leftrightarrow<tab>`), `⇔` (`\Leftrightarrow<tab>`) |
+| EQUIVALENCE | `<-->`, `===`, `≡` (`\equiv<tab>`), `↔` (`\leftrightarrow<tab>`), `⇔` (`\Leftrightarrow<tab>`) |
 
 Examples:
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ This is the list of symbols that can be used:
 | XOR  | `⊻` (`\xor<tab>`) |
 | NAND | `⊼` (`\nand<tab>`) |
 | NOR  | `⊽` (`\nor<tab>`) |
-| IMPLICATION | `-->` |
+| IMPLICATION | `-->`, `→` (`\to<tab>` or `\rightarrow<tab>`) |
 | EQUIVALENCE | `<-->`, `≡` (`\equiv<tab>`) |
 
 Examples:

--- a/src/TruthTables.jl
+++ b/src/TruthTables.jl
@@ -4,7 +4,7 @@ using Tables, PrettyTables
 
 export @truthtable
 export -->, <-->
-export ∧, ∨, ¬
+export ∧, ∨, ¬, →
 
 include("showmode.jl")
 include("truthtable.jl")

--- a/src/macro.jl
+++ b/src/macro.jl
@@ -21,8 +21,8 @@ If `full` is `true`, the truth table will be created in expanded form.
 * XOR: `⊻` (`\\xor<tab>`)
 * NAND: `⊼` (`\\nand<tab>`)
 * NOR: `⊽` (`\\nor<tab>`)
-* IMPLICATION: `-->`, `→` (`\\to<tab>` or `\\rightarrow<tab>`)
-* EQUIVALENCE: `<-->`, `≡` (`\\equiv<tab>`)
+* IMPLICATION: `-->`, `→` (`\\to<tab>` or `\\rightarrow<tab>`), `⇒` ( `\\Rightarrow<tab>`)
+* EQUIVALENCE: `<-->`, `≡` (`\\equiv<tab>`), `↔` (`\\leftrightarrow<tab>`), `⇔` (`\\Leftrightarrow<tab>`)
 
 # Examples
 

--- a/src/macro.jl
+++ b/src/macro.jl
@@ -1,4 +1,5 @@
 (-->)(x::Bool, y::Bool) = !x || y
+(→)(x::Bool, y::Bool) = !x || y
 (<-->)(x::Bool, y::Bool) = x ≡ y
 ∧(x::Bool, y::Bool) = x && y
 ∨(x::Bool, y::Bool) = x || y
@@ -82,7 +83,7 @@ If `full` is `true`, the truth table will be created in expanded form.
 * XOR: `⊻` (`\\xor<tab>`)
 * NAND: `⊼` (`\\nand<tab>`)
 * NOR: `⊽` (`\\nor<tab>`)
-* IMPLICATION: `-->`
+* IMPLICATION: `-->`, `→` (`\\to<tab>` or `\\rightarrow<tab>`)
 * EQUIVALENCE: `<-->`, `≡` (`\\equiv<tab>`)
 
 # Examples

--- a/src/macro.jl
+++ b/src/macro.jl
@@ -22,7 +22,7 @@ If `full` is `true`, the truth table will be created in expanded form.
 * NAND: `⊼` (`\\nand<tab>`)
 * NOR: `⊽` (`\\nor<tab>`)
 * IMPLICATION: `-->`, `→` (`\\to<tab>` or `\\rightarrow<tab>`), `⇒` ( `\\Rightarrow<tab>`)
-* EQUIVALENCE: `<-->`, `≡` (`\\equiv<tab>`), `↔` (`\\leftrightarrow<tab>`), `⇔` (`\\Leftrightarrow<tab>`)
+* EQUIVALENCE: `<-->`, `===`, `≡` (`\\equiv<tab>`), `↔` (`\\leftrightarrow<tab>`), `⇔` (`\\Leftrightarrow<tab>`)
 
 # Examples
 

--- a/src/macro.jl
+++ b/src/macro.jl
@@ -1,5 +1,5 @@
 (-->)(x::Bool, y::Bool) = !x || y
-(→)(x::Bool, y::Bool) = !x || y
+→(x::Bool, y::Bool) = !x || y
 (<-->)(x::Bool, y::Bool) = x ≡ y
 ∧(x::Bool, y::Bool) = x && y
 ∨(x::Bool, y::Bool) = x || y

--- a/src/macroutils.jl
+++ b/src/macroutils.jl
@@ -70,7 +70,10 @@ end
         str = string(expr)
         str = replace(str, r"&{2}|&" => "∧")
         str = replace(str, r"\|{2}|\|" => "∨")
-        Symbol(replace(str, r"!|~" => "¬"))
+        str = replace(str, r"!|~" => "¬")
+        str = replace(str, r"→|⇒" => "-->")
+        str = replace(str, r"↔|⇔" => "<-->")
+        Symbol(replace(str, "===" => "≡"))
     end
 else
     function exprname(expr::Expr)
@@ -78,7 +81,10 @@ else
         str = replace(str,
             r"&{2}|&" => "∧",
             r"\|{2}|\|" => "∨",
-            r"!|~" => "¬"
+            r"!|~" => "¬",
+            r"→|⇒" => "-->",
+            r"↔|⇔" => "<-->",
+            "===" => "≡"
         )
         Symbol(str)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -226,6 +226,11 @@ using TruthTables: TruthTable
         @test (false --> true) == true
         @test (false --> false) == true
 
+        @test (true → true) == true
+        @test (true → false) == false
+        @test (false → true) == true
+        @test (false → false) == true
+
         @test (true <--> true) == true
         @test (true <--> false) == false
         @test (false <--> true) == false


### PR DESCRIPTION
To resolve #18, this PR add the new operator → (`\to<tab>` or `\rightarrow<tab>`) by adding:
- Code and docstring in `macros.jl`
- The operator in `README.md`
- Tests in `runtests.jl`
- The export of the operator in `TruthTables.jl`