### PR TITLE
Refactor: `@truthtable` macro

### DIFF
--- a/src/macro.jl
+++ b/src/macro.jl
@@ -1,10 +1,3 @@
-function _kwarg(expr::Expr)::Bool
-  if expr.head == :(=) && expr.args[1] == :full
-    return expr.args[2]
-  end
-  throw(ArgumentError("Invalid kwarg expression"))
-end
-
 """
     @truthtable formula [full=false]
 

--- a/src/macro.jl
+++ b/src/macro.jl
@@ -108,28 +108,24 @@ macro truthtable(expr)
 end
 
 function _truthtable(expr::Expr, full::Bool)
-  preprocess!(expr)
-
-  colnames = propnames(expr)
-  columns  = gencolumns(length(colnames))
   colexprs = Expr[]
+  colnames = _propnames(expr)
+  columns = _gencolumns(length(colnames))
+  colmap = Dict(zip(colnames, columns))
 
   if full
-    subexprs = getsubexprs(expr)
+    subexprs = _subexprs(expr)
     for subexpr in subexprs
-      nms = propnames(subexpr)
-      inds = indexin(nms, colnames)
-      colexpr = :(map(($(nms...),) -> $subexpr, $(columns[inds]...)))
-      push!(colnames, exprname(subexpr))
-      push!(colexprs, colexpr)
+      push!(colnames, _exprname(subexpr))
+      push!(colexprs, _colexpr(subexpr))
     end
   else
-    colexpr = :(map(($(colnames...),) -> $expr, $(columns...)))
-    push!(colnames, exprname(expr))
-    push!(colexprs, colexpr)
+    push!(colnames, _exprname(expr))
+    push!(colexprs, _colexpr(expr))
   end
 
-  return quote
+  quote
+    local colmap = $colmap
     TruthTable([$(columns...), $(colexprs...)], $colnames)
   end
 end

--- a/src/macro.jl
+++ b/src/macro.jl
@@ -103,7 +103,7 @@ end
 function _truthtable(expr::Expr, full::Bool)
   colexprs = Expr[]
   colnames = _propnames(expr)
-  columns = _gencolumns(length(colnames))
+  columns = _propcolumns(length(colnames))
   colmap = Dict(zip(colnames, columns))
 
   if full

--- a/src/macroutils.jl
+++ b/src/macroutils.jl
@@ -67,11 +67,11 @@ function _propnames(expr::Expr)
   props = Symbol[]
   _propnames!(props, expr)
   unique!(props)
-  return props
+  props
 end
 
 function _propnames!(props::Vector{Symbol}, expr::Expr)
-  b = expr.head == :call ? 2 : 1
+  b = expr.head === :call ? 2 : 1
   for i in length(expr.args):-1:b
     arg = expr.args[i]
     if arg isa Expr
@@ -88,11 +88,11 @@ _propname(x::Symbol) = x
 function _subexprs(expr::Expr)
   exprs = [expr]
   _subexprs!(exprs, expr)
-  return exprs
+  exprs
 end
 
 function _subexprs!(exprs::Vector{Expr}, expr::Expr)
-  b = expr.head == :call ? 2 : 1
+  b = expr.head === :call ? 2 : 1
   for i in length(expr.args):-1:b
     arg = expr.args[i]
     if arg isa Expr

--- a/src/macroutils.jl
+++ b/src/macroutils.jl
@@ -41,7 +41,7 @@ function _preprocess!(expr::Expr)
     throw(ArgumentError("Expression with invalid operator"))
   end
 
-  pushfirst!(expr.args, :broadcast)
+  pushfirst!(expr.args, :map)
 
   for i in 3:length(expr.args)
     arg = expr.args[i]

--- a/src/macroutils.jl
+++ b/src/macroutils.jl
@@ -1,3 +1,10 @@
+function _kwarg(expr::Expr)::Bool
+  if !Meta.isexpr(expr, :(=), 2) || expr.args[1] !== :full
+    throw(ArgumentError("Invalid kwarg expression"))
+  end
+  expr.args[2]
+end
+
 function _gencolumns(n::Integer)
   bools = [true, false]
   outers = [2^x for x in 0:n-1]

--- a/src/macroutils.jl
+++ b/src/macroutils.jl
@@ -79,7 +79,7 @@ end
 
 function _propnames!(props::Vector{Symbol}, expr::Expr)
   b = expr.head === :call ? 2 : 1
-  for i in length(expr.args):-1:b
+  for i in b:length(expr.args)
     arg = expr.args[i]
     if arg isa Expr
       _propnames!(props, arg)

--- a/src/truthtable.jl
+++ b/src/truthtable.jl
@@ -4,7 +4,7 @@ struct TruthTable
   colnames::Vector{Symbol}
 end
 
-function TruthTable(columns::Vector{<:AbstractVector{Bool}}, colnames::Vector{Symbol})
+function TruthTable(columns::Vector{Vector{Bool}}, colnames::Vector{Symbol})
   colindex = Dict(k => i for (i, k) in enumerate(colnames))
   TruthTable(columns, colindex, colnames)
 end

--- a/src/truthtable.jl
+++ b/src/truthtable.jl
@@ -4,8 +4,8 @@ struct TruthTable
   colnames::Vector{Symbol}
 end
 
-function TruthTable(columns::Vector{Vector{Bool}}, colnames::Vector{Symbol})
-  colindex = Dict(k => i for (i, k) in pairs(colnames))
+function TruthTable(columns::Vector{<:AbstractVector{Bool}}, colnames::Vector{Symbol})
+  colindex = Dict(k => i for (i, k) in enumerate(colnames))
   TruthTable(columns, colindex, colnames)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -75,7 +75,7 @@ using TruthTables: ∧, ∨, -->, <-->, ¬, →, ↔, ⇒, ⇔
     @test TruthTables._propnames(expr) == [:p, :q, :r]
     @test TruthTables._subexprs(expr) == [:(p && q), :(p && q --> r)]
     @test TruthTables._exprname(expr) == Symbol("p ∧ q --> r")
-    @test TruthTables._colexpr(expr) == :(broadcast(-->, broadcast(&, colmap[:p], colmap[:q]), colmap[:r]))
+    @test TruthTables._colexpr(expr) == :(map(-->, map(&, colmap[:p], colmap[:q]), colmap[:r]))
 
     @test_throws ArgumentError TruthTables._propname(1)
     @test_throws ArgumentError TruthTables._kwarg(:(full => true))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -77,9 +77,24 @@ using TruthTables: ∧, ∨, -->, <-->, ¬, →, ↔, ⇒, ⇔
     @test TruthTables._exprname(expr) == Symbol("p ∧ q --> r")
     @test TruthTables._colexpr(expr) == :(map(-->, map(&, colmap[:p], colmap[:q]), colmap[:r]))
 
+    @test TruthTables._propcolumns(1) == [Bool[1, 0]]
+    @test TruthTables._propcolumns(2) == [Bool[1, 1, 0, 0], Bool[1, 0, 1, 0]]
+    @test TruthTables._propcolumns(3) == [
+      Bool[1, 1, 1, 1, 0, 0, 0, 0],
+      Bool[1, 1, 0, 0, 1, 1, 0, 0],
+      Bool[1, 0, 1, 0, 1, 0, 1, 0]
+    ]
+    @test TruthTables._propcolumns(4) == [
+      Bool[1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0],
+      Bool[1, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0],
+      Bool[1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0],
+      Bool[1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0]
+    ]
+
     @test_throws ArgumentError TruthTables._propname(1)
     @test_throws ArgumentError TruthTables._kwarg(:(full => true))
     @test_throws ArgumentError TruthTables._colexpr(:(p + q))
+    @test_throws ArgumentError TruthTables._colexpr(:(p ? q : r))
   end
 
   @testset "TruthTable show" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,7 +52,7 @@ using TruthTables: ∧, ∨, -->, <-->, ¬, →, ↔, ⇒, ⇔
     @test Tables.getcolumn(tt, :q) == Bool[1, 0, 1, 0]
     @test Tables.getcolumn(tt, Symbol("p ∨ q")) == Bool[1, 1, 1, 0]
 
-    tt = @truthtable !(x || y) <--> (!x && !y) full = true
+    tt = @truthtable !(x || y) <--> (!x && !y) full=true
     @test Tables.getcolumn(tt, 1) == Bool[1, 1, 0, 0]
     @test Tables.getcolumn(tt, 2) == Bool[1, 0, 1, 0]
     @test Tables.getcolumn(tt, 3) == Bool[1, 1, 1, 0]
@@ -72,15 +72,14 @@ using TruthTables: ∧, ∨, -->, <-->, ¬, →, ↔, ⇒, ⇔
 
     # helper functions
     expr = :(p && q --> r)
-    @test TruthTables.propnames(expr) == [:p, :q, :r]
-    @test TruthTables.getsubexprs(expr) == [:(p && q), :(p && q --> r)]
-    @test TruthTables.exprname(expr) == Symbol("p ∧ q --> r")
-    TruthTables.preprocess!(expr)
-    @test expr.head == :call && expr.args[1] == :(-->)
+    @test TruthTables._propnames(expr) == [:p, :q, :r]
+    @test TruthTables._subexprs(expr) == [:(p && q), :(p && q --> r)]
+    @test TruthTables._exprname(expr) == Symbol("p ∧ q --> r")
+    @test TruthTables._colexpr(expr) == :(broadcast(-->, broadcast(&, colmap[:p], colmap[:q]), colmap[:r]))
 
     @test_throws ArgumentError TruthTables._propname(1)
     @test_throws ArgumentError TruthTables._kwarg(:(full => true))
-    @test_throws ArgumentError TruthTables.preprocess!(:(p + q))
+    @test_throws ArgumentError TruthTables._colexpr(:(p + q))
   end
 
   @testset "TruthTable show" begin
@@ -143,7 +142,7 @@ using TruthTables: ∧, ∨, -->, <-->, ¬, →, ↔, ⇒, ⇔
 
     # show mode: :bool (default)
     TruthTables.showmode!()
-    tt = @truthtable p && (q || r) full = true
+    tt = @truthtable p && (q || r) full=true
     str = """
     TruthTable
     ┌───────┬───────┬───────┬───────┬─────────────┐


### PR DESCRIPTION
This PR is a refactoring of the `@truthtable` macro to make it more efficient.
Benchmarks:
main:
```julia
julia> @time @eval @truthtable !(x || y) <--> (!x && !y) full=true
  0.617676 seconds (2.64 M allocations: 134.338 MiB, 6.41% gc time, 98.37% compilation time)
TruthTable
...

julia> @time @eval @truthtable !(x || y) <--> (!x && !y) full=true
  0.136912 seconds (370.69 k allocations: 18.694 MiB, 96.07% compilation time)
TruthTable
...

julia> @time @eval @truthtable !(x || y) <--> (!x && !y) full=true
  0.141954 seconds (370.68 k allocations: 18.689 MiB, 96.22% compilation time)
TruthTable
...
```
This PR:
```julia
julia> @time @eval @truthtable !(x || y) <--> (!x && !y) full=true
  0.531565 seconds (2.17 M allocations: 111.631 MiB, 5.38% gc time, 98.84% compilation time)
TruthTable
...

julia> @time @eval @truthtable !(x || y) <--> (!x && !y) full=true
  0.001128 seconds (515 allocations: 26.062 KiB, 0.02% compilation time)
TruthTable
...

julia> @time @eval @truthtable !(x || y) <--> (!x && !y) full=true
  0.001776 seconds (512 allocations: 25.969 KiB, 0.03% compilation time)
TruthTable
...
```