### PR TITLE
Faster implementation of `_varnames` function

### DIFF
--- a/src/macroutils.jl
+++ b/src/macroutils.jl
@@ -19,7 +19,6 @@ Returns the names of propositional variables from the logical expression.
 function _varnames(expr::Expr)
   names = Symbol[]
   _varnames!(names, expr)
-  unique!(names)
   names
 end
 
@@ -29,14 +28,13 @@ function _varnames!(names::Vector{Symbol}, expr::Expr)
     arg = expr.args[i]
     if arg isa Expr
       _varnames!(names, arg)
+    elseif arg isa Symbol
+      arg ∉ names && push!(names, arg)
     else
-      push!(names, _varname(arg))
+      throw(ArgumentError("Expression with invalid propositional variable"))
     end
   end
 end
-
-_varname(name::Symbol) = name
-_varname(::Any) = throw(ArgumentError("Expression with invalid propositional variable"))
 
 """
     _varcolumns(n) -> Vector{Vector{Bool}}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -91,8 +91,8 @@ using TruthTables: ∧, ∨, -->, <-->, ¬, →, ↔, ⇒, ⇔
       Bool[1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0]
     ]
 
-    @test_throws ArgumentError TruthTables._varname(1)
     @test_throws ArgumentError TruthTables._kwarg(:(full => true))
+    @test_throws ArgumentError TruthTables._varnames(:(p && 1))
     @test_throws ArgumentError TruthTables._colexpr(:(p + q))
     @test_throws ArgumentError TruthTables._colexpr(:(p ? q : r))
   end


### PR DESCRIPTION
Benchmark:
```julia
julia> using TruthTables

julia> using BenchmarkTools

julia> expr = :((p & q | r) & (r & q | p))
:((p & q | r) & (r & q | p))
```
main:
```julia
julia> @btime TruthTables._varnames($expr)
  230.320 ns (6 allocations: 512 bytes)
3-element Vector{Symbol}:
 :p
 :q
 :r
```
This PR:
```julia
julia> @btime TruthTables._varnames($expr)
  73.264 ns (2 allocations: 128 bytes)
3-element Vector{Symbol}:
 :p
 :q
 :r
```