### PR TITLE
Add type assertion to `_kwarg` function return

### DIFF
--- a/src/macroutils.jl
+++ b/src/macroutils.jl
@@ -4,11 +4,11 @@
 Validates the kwarg expression of the `@truthtable` macro.
 If the expression is valid, the value of the kwarg expression is returned.
 """
-function _kwarg(expr::Expr)::Bool
+function _kwarg(expr::Expr)
   if !Meta.isexpr(expr, :(=), 2) || expr.args[1] !== :full
     throw(ArgumentError("Invalid kwarg expression"))
   end
-  expr.args[2]
+  expr.args[2]::Bool
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -91,6 +91,8 @@ using TruthTables: ∧, ∨, -->, <-->, ¬, →, ↔, ⇒, ⇔
       Bool[1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0]
     ]
 
+    @test_throws TypeError TruthTables._kwarg(:(full=1))
+    @test_throws ArgumentError TruthTables._kwarg(:(test=true))
     @test_throws ArgumentError TruthTables._kwarg(:(full => true))
     @test_throws ArgumentError TruthTables._varnames(:(p && 1))
     @test_throws ArgumentError TruthTables._colexpr(:(p + q))


### PR DESCRIPTION
On the main branch, this expression does not throw an error:
```julia
julia> @truthtable p & (~q | r) full=1
TruthTable
┌───────┬───────┬───────┬───────┬────────┬──────────────┐
│   p   │   q   │   r   │  ¬q   │ ¬q ∨ r │ p ∧ (¬q ∨ r) │
├───────┼───────┼───────┼───────┼────────┼──────────────┤
│ true  │ true  │ true  │ false │ true   │ true         │
│   ⋮   │   ⋮   │   ⋮   │   ⋮   │   ⋮    │      ⋮       │
│ false │ false │ false │ true  │ true   │ false        │
└───────┴───────┴───────┴───────┴────────┴──────────────┘
                                           6 rows omitted
```
This PR solve this issue by adding a type assertion to `_kwarg` function return:
```julia
julia> @truthtable p & (~q | r) full=1
ERROR: TypeError: non-boolean (Int64) used in boolean context
Stacktrace:
  [1] _kwarg(expr::Expr)
...
```